### PR TITLE
Make work with JAX-RS

### DIFF
--- a/project-code/app/org/apache/cxf/transport/play/CxfController.scala
+++ b/project-code/app/org/apache/cxf/transport/play/CxfController.scala
@@ -34,6 +34,7 @@ class CxfController extends Controller {
     val msg: Message = new MessageImpl
     msg.put(Message.HTTP_REQUEST_METHOD, request.method)
     msg.put(Message.REQUEST_URL, request.path)
+    msg.put(Message.REQUEST_URI, request.uri)
     msg.put(Message.QUERY_STRING, request.rawQueryString)
     msg.put(Message.PROTOCOL_HEADERS, headersAsJava)
     msg.put(Message.CONTENT_TYPE, request.headers.get(Message.CONTENT_TYPE) getOrElse null)

--- a/project-code/app/org/apache/cxf/transport/play/PlayTransportFactory.java
+++ b/project-code/app/org/apache/cxf/transport/play/PlayTransportFactory.java
@@ -81,6 +81,11 @@ public class PlayTransportFactory extends AbstractTransportFactory
     }
 
     public PlayDestination getDestination(String endpointAddress) {
+        for (java.util.Map.Entry<String, PlayDestination> e: destinations.entrySet()) {
+          if (endpointAddress.startsWith(e.getKey())) {
+            return e.getValue();
+          }
+        }
         return destinations.get(endpointAddress);
     }
 


### PR DESCRIPTION
Made some modifications to support JAX-RS web services. In particular, a
route only needs to match the beginning of an endpoint address to work.
This allows to pass parameters in the path to the JAX-RS webservices.
Also now we send the URI in the message to the webservice.