### PR TITLE
Http return code based on SOAP error interceptor

### DIFF
--- a/project-code/app/org/apache/cxf/transport/play/CxfController.scala
+++ b/project-code/app/org/apache/cxf/transport/play/CxfController.scala
@@ -40,10 +40,11 @@ class CxfController extends Controller with FactoryBean[CxfController] {
       delayedOutput.setTarget(os)
     }
     replyPromise.future.map { outMessage =>
+      val httpCode = Option(outMessage.get(Message.RESPONSE_CODE)) map (_.toString) map (_.toInt) getOrElse OK
+      val contentType = outMessage.get(Message.CONTENT_TYPE).asInstanceOf[String]
+
       val enumerator = resultEnumerator >>> Enumerator.eof
-      Ok.chunked(Source.fromPublisher(Streams.enumeratorToPublisher(enumerator))) withHeaders(
-        Message.CONTENT_TYPE -> outMessage.get(Message.CONTENT_TYPE).asInstanceOf[String]
-      )
+      new Status(httpCode).chunked(Source.fromPublisher(Streams.enumeratorToPublisher(enumerator))) as contentType
     }
   }
 


### PR DESCRIPTION
- Http return code based on SOAP error interceptor
- Changed withHeaders() to as() to eliminate warning error